### PR TITLE
Use threads in ThreadLocalExample to show that it doesn't work

### DIFF
--- a/src/main/java/com/lambdaherding/edi/ch02/ThreadLocalExample.java
+++ b/src/main/java/com/lambdaherding/edi/ch02/ThreadLocalExample.java
@@ -9,6 +9,26 @@ import java.util.Date;
 /**
  * This class is not thread-safe! Turn the static formatter into a ThreadLocal version of it,
  * using lambdas for simplicity.
+ * 
+ * Comparrison Output:
+ * 
+ * Thread safe:
+ * <code>
+ * 02-03-2017
+ * 01-03-2017
+ * 01-04-2017
+ * 03-03-2017
+ * 30-06-2064
+ * 30-09-2111
+ * </code>
+ * 
+ * Not thread safe:
+ * 01-03-2017
+ * 02-03-2017
+ * 01-03-2017
+ * 01-04-2017
+ * 01-04-2017
+ * 01-04-2017
  */
 public class ThreadLocalExample {
 	private static final SimpleDateFormat FORMATTER = new SimpleDateFormat( "dd-MM-yyyy" );
@@ -22,7 +42,12 @@ public class ThreadLocalExample {
 	}
 
 	public static void main( String[] args ) {
-		ThreadLocalExample.show( 31, Month.MARCH, 2017 );
-		ThreadLocalExample.show( 1491004800_000L );
+		for ( int i = 1; i <= 3; i++ ) {
+			final int day = i; // Must be final or effectively final!
+			new Thread( () -> {
+				ThreadLocalExample.show( day, Month.MARCH, 2017 );
+				ThreadLocalExample.show( 1491004800_000L * new Long(day) ); // little bit silly, but shows up nicely in the comparative output
+			}).start();
+		}
 	}
 }

--- a/src/main/java/com/lambdaherding/edi/ch02/ThreadLocalExample.java
+++ b/src/main/java/com/lambdaherding/edi/ch02/ThreadLocalExample.java
@@ -10,7 +10,10 @@ import java.util.Date;
  * This class is not thread-safe! Turn the static formatter into a ThreadLocal version of it,
  * using lambdas for simplicity.
  * 
- * Comparrison Output:
+ * Comparison Output:
+ *
+ * Of course you'll get different results between runs,  but the important part is that we have
+ * 4 01-04-2017 entries 2 01-03-2017 entries and a single 02-03-2017 entry when they should all be unique.
  * 
  * Thread safe:
  * <code>
@@ -23,12 +26,14 @@ import java.util.Date;
  * </code>
  * 
  * Not thread safe:
+ * <code>
  * 01-03-2017
  * 02-03-2017
  * 01-03-2017
  * 01-04-2017
  * 01-04-2017
  * 01-04-2017
+ * </code>
  */
 public class ThreadLocalExample {
 	private static final SimpleDateFormat FORMATTER = new SimpleDateFormat( "dd-MM-yyyy" );


### PR DESCRIPTION
I thought I'd update the example to actually show the problems that can come up when not using something that is ThreadSafe (example output it in the JavaDoc). 

Trying to keep this one isolated from my merge request in case others want to use the example (although it's a little bit late for some people).